### PR TITLE
Adds dependabot auto-merge configuration

### DIFF
--- a/.github/workflows
+++ b/.github/workflows
@@ -1,0 +1,14 @@
+name: auto-merge
+
+on:
+  pull_request:
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ahmadnassri/action-dependabot-auto-merge@v2
+        with:
+          target: minor
+          github-token: ${{ secrets.AUTO_MERGE }}


### PR DESCRIPTION
This PR adds dependabot [auto-merge](https://github.com/marketplace/actions/dependabot-auto-merge) to the repository.

Please ensure you have creacted a GitHub token called `AUTO_MERGE` as per the instructions [here](https://github.com/marketplace/actions/dependabot-auto-merge#token-scope).

---

*This change was executed automatically with [Shepherd](https://github.com/NerdWalletOSS/shepherd).* 💚🤖